### PR TITLE
RN 0.80+ : pod install fails / don't depend of RCT-Folly on RN 0.80+

### DIFF
--- a/react-native-apple-llm.podspec
+++ b/react-native-apple-llm.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.version                 = package['version']
   s.summary                 = package["description"]
   s.homepage                = "https://github.com/deveix/react-native-apple-llm"
-  s.license                 = { :type => package["license"], :file => "LICENSE" }
+  s.license                 = { :type => package["license"], :file => "LICENSE.md" }
   s.authors                 = { package["author"]["name"] => package["author"]["email"] }
 
   s.ios.deployment_target   = '13.0'


### PR DESCRIPTION
I've tested react-native-apple-llm with RN 0.81 (on Expo SDK 54 Beta). It's impossible to run a build with new version of React Native as dependencies are not available but prebuilt. I took example on this PR to fix this : https://github.com/dominicstop/react-native-ios-utilities/pull/30/files